### PR TITLE
Attach original PGP message

### DIFF
--- a/gpg-mailgate.conf.sample
+++ b/gpg-mailgate.conf.sample
@@ -48,6 +48,11 @@ dec_regex = None
 # (see INSTALL for details)
 keyhome = /var/gpgmailgate/.gnupg
 
+# When decrypting a mail, the original signature information is lost. With this
+# setting, the original encrypted message and GPG output will be saved as
+# additional attachments to the mail. This allows for later manual verifcation.
+attach_original = no
+
 [smime]
 # the directory for the S/MIME certificate files
 cert_path = /var/gpgmailgate/smime

--- a/gpg-mailgate.py
+++ b/gpg-mailgate.py
@@ -20,6 +20,7 @@
 #
 
 from ConfigParser import RawConfigParser
+from email import encoders
 from email.mime.base import MIMEBase
 from email.mime.multipart import MIMEMultipart
 import copy
@@ -153,7 +154,12 @@ def gpg_decrypt_all_payloads( message ):
 		# Check if message is PGP/INLINE encrypted without attachments (or unencrypted without attachments)
 		else:
 			decrypted_message = decrypt_inline_without_attachments(decrypted_message)
-
+	if cfg['gpg']['attach_original'] == "yes" and success:
+		attachment = MIMEBase('text', 'plain')
+		attachment.set_payload(message.as_string())
+		encoders.encode_base64(attachment)
+		attachment.add_header('Content-Disposition', 'attachment; filename="original-mail.txt"')
+		decrypted_message.attach(attachment)
 	return decrypted_message
 
 def decrypt_mime( decrypted_message ):

--- a/gpg-mailgate.py
+++ b/gpg-mailgate.py
@@ -29,8 +29,10 @@ import email.message
 import email.utils
 import GnuPG
 import os
+import random
 import re
 import smtplib
+import string
 import sys
 import syslog
 import traceback
@@ -158,7 +160,8 @@ def gpg_decrypt_all_payloads( message ):
 		attachment = MIMEBase('text', 'plain')
 		attachment.set_payload(message.as_string())
 		encoders.encode_base64(attachment)
-		attachment.add_header('Content-Disposition', 'attachment; filename="original-mail.txt"')
+		attachment.add_header('Content-Disposition', 'attachment; filename="original-mail-{}.txt"'.format(
+			''.join([random.choice(string.ascii_letters + string.digits) for n in range(12)])))
 		decrypted_message.attach(attachment)
 	return decrypted_message
 


### PR DESCRIPTION
Not sure if this is helpful for anybody, but I need some sort of audit trail. Therefore I need to keep a copy of the original signed PGP message in an text/plain attachment.