### PR TITLE
Unicode fix

### DIFF
--- a/gpg-mailgate.py
+++ b/gpg-mailgate.py
@@ -638,7 +638,7 @@ def send_msg( message, recipients ):
 		smtp = smtplib.SMTP(relay[0], relay[1])
 		if 'relay' in cfg and 'starttls' in cfg['relay'] and cfg['relay']['starttls'] == 'yes':
 			smtp.starttls()
-		smtp.sendmail( from_addr, recipients, message )
+		smtp.sendmail( from_addr, recipients, message.encode() ) // convert to bytes for unicode support
 	else:
 		log("No recipient found")
 

--- a/gpg-mailgate.py
+++ b/gpg-mailgate.py
@@ -469,7 +469,7 @@ def encrypt_all_payloads_mime( message, gpg_to_cmdline ):
 
 def encrypt_payload( payload, gpg_to_cmdline, check_nested = True ):
 
-	raw_payload = payload.get_payload(decode=True)
+	raw_payload = payload.get_payload().encode()
 	if check_nested and b"-----BEGIN PGP MESSAGE-----" in raw_payload and b"-----END PGP MESSAGE-----" in raw_payload:
 		if verbose:
 			log("Message is already pgp encrypted. No nested encryption needed.")

--- a/gpg-mailgate.py
+++ b/gpg-mailgate.py
@@ -638,7 +638,7 @@ def send_msg( message, recipients ):
 		smtp = smtplib.SMTP(relay[0], relay[1])
 		if 'relay' in cfg and 'starttls' in cfg['relay'] and cfg['relay']['starttls'] == 'yes':
 			smtp.starttls()
-		smtp.sendmail( from_addr, recipients, message.encode() ) // convert to bytes for unicode support
+		smtp.sendmail( from_addr, recipients, message.encode() ) # convert to bytes for unicode support
 	else:
 		log("No recipient found")
 


### PR DESCRIPTION
This is a minor fix to mitigate the following problem:

the gpg-mailgate.py works nicely as long emails contain only ascii chars:

`date | mail -s Test your-mail@example.com` nicely encodes the mail, if a respective gpg key is present.

However, if you did something like this:

`echo "German text may contain letters like ÄäÖöÜüß and others" | mail -s Test your-mail@example.com` it will fail, as smtp.sendmail only accepts ascii strings _OR_ byte data.

This patch fixes that problem.