### PR TITLE
we need to convert to string to concatenate

### DIFF
--- a/gpg-mailgate.py
+++ b/gpg-mailgate.py
@@ -445,7 +445,7 @@ def encrypt_all_payloads_mime( message, gpg_to_cmdline ):
 		additionalSubHeader=""
 		if 'Content-Type' in message and not message['Content-Type'].startswith('multipart'):
 			additionalSubHeader="Content-Type: "+message['Content-Type']+"\n"
-		submsg2.set_payload(additionalSubHeader+"\n" +message.get_payload(decode=True))
+		submsg2.set_payload(additionalSubHeader+"\n" +message.get_payload(decode=True).decode("utf-8"))
 		check_nested = True
 	else:
 		processed_payloads = generate_message_from_payloads(message)


### PR DESCRIPTION
message.get_payload(decode=True) always returns bytes when decode is set to true. we need to convert to string before we concatenate